### PR TITLE
gnome desktop dark wallpaper support

### DIFF
--- a/dwall.sh
+++ b/dwall.sh
@@ -369,7 +369,7 @@ while getopts ":hdpklas:b:o:" opt; do
 			{ reset_color; exit 1; }
 			;;
 		:)
-			echo -e ${RED}"[!] Invalid:$G -$OPTARG$R requires an argument."
+			echo -e ${RED}"[!] Invalid:${GREEN} -$OPTARG${RED} requires an argument."
 			{ reset_color; exit 1; }
 			;;
 	esac

--- a/dwall.sh
+++ b/dwall.sh
@@ -29,18 +29,18 @@ DEBUG=false
 reset_color() {
 	tput sgr0   # reset attributes
 	tput op     # reset color
-    return
+	return
 }
 
 ## Script Termination
 exit_on_signal_SIGINT() {
-    { printf "${RED}\n\n%s\n\n" "[!] Program Interrupted." 2>&1; reset_color; }
-    exit 0
+	{ printf "${RED}\n\n%s\n\n" "[!] Program Interrupted." 2>&1; reset_color; }
+	exit 0
 }
 
 exit_on_signal_SIGTERM() {
-    { printf "${RED}\n\n%s\n\n" "[!] Program Terminated." 2>&1; reset_color; }
-    exit 0
+	{ printf "${RED}\n\n%s\n\n" "[!] Program Terminated." 2>&1; reset_color; }
+	exit 0
 }
 
 trap exit_on_signal_SIGINT SIGINT
@@ -48,19 +48,19 @@ trap exit_on_signal_SIGTERM SIGTERM
 
 ## Prerequisite
 Prerequisite() { 
-    dependencies=(feh grep xargs)
-    for dependency in "${dependencies[@]}"; do
-        type -p "$dependency" &>/dev/null || {
-            echo -e ${RED}"[!] ERROR: Could not find ${GREEN}'${dependency}'${RED}, is it installed?" >&2
-            { reset_color; exit 1; }
-        }
-    done
+	dependencies=(feh grep xargs)
+	for dependency in "${dependencies[@]}"; do
+		type -p "$dependency" &>/dev/null || {
+			echo -e ${RED}"[!] ERROR: Could not find ${GREEN}'${dependency}'${RED}, is it installed?" >&2
+			{ reset_color; exit 1; }
+		}
+	done
 }
 
 ## Usage
 usage() {
 	clear
-    cat <<- EOF
+	cat <<- EOF
 		${RED}╺┳┓╻ ╻┏┓╻┏━┓┏┳┓╻┏━╸   ${GREEN}╻ ╻┏━┓╻  ╻  ┏━┓┏━┓┏━┓┏━╸┏━┓
 		${RED} ┃┃┗┳┛┃┗┫┣━┫┃┃┃┃┃     ${GREEN}┃╻┃┣━┫┃  ┃  ┣━┛┣━┫┣━┛┣╸ ┣┳┛
 		${RED}╺┻┛ ╹ ╹ ╹╹ ╹╹ ╹╹┗━╸   ${GREEN}┗┻┛╹ ╹┗━╸┗━╸╹  ╹ ╹╹  ┗━╸╹┗╸
@@ -79,7 +79,7 @@ usage() {
 		    -l                           Force light color scheme 
 		    -a                           Automatically set light/dark color scheme based on GNOME theme or daytime 
 		  -o                             Output wallpaper to file instead of setting it
-		  -k							 Keep running in a loop, use with exec in sway or i3
+		  -k                             Keep running in a loop, use with exec in sway or i3
 		  -d                             Turn on debug messages
 	EOF
 
@@ -88,7 +88,7 @@ usage() {
 	printf -- ${ORANGE}'%s  ' "${styles[@]}"
 	printf -- '\n\n'${WHITE}
 
-    cat <<- EOF
+	cat <<- EOF
 		Examples:
 		`basename $0` -s beach                   Set 'beach' style wallpaper
 		`basename $0` -s beach -o ~/.wallpaper   Save 'beach' style wallpaper into file '~/.wallpaper'
@@ -157,7 +157,7 @@ set_pantheon() {
 
 ## Set wallpaper in sway
 set_sway() {
-    swaymsg -p -t get_outputs | grep Output | awk {'print $2'} | xargs -I {} ogurictl output {} --image $1
+	swaymsg -p -t get_outputs | grep Output | awk {'print $2'} | xargs -I {} ogurictl output {} --image $1
 }
 
 ## For XFCE only
@@ -345,7 +345,7 @@ while getopts ":hdpklas:b:o:" opt; do
 			;;
 		o)
 			OUTPUT=$OPTARG
-      ;;
+			;;
 		b)
 			WALBACKEND=$OPTARG
 			;;
@@ -379,7 +379,7 @@ done
 Prerequisite
 if [[ "$STYLE" ]]; then
 	check_style "$STYLE"
-    main
+	main
 else
 	{ usage; reset_color; exit 1; }
 fi

--- a/dwall.sh
+++ b/dwall.sh
@@ -93,7 +93,7 @@ usage() {
 		Examples:
 		`basename $0` -s beach                   Set 'beach' style wallpaper
 		`basename $0` -s beach -o ~/.wallpaper   Save 'beach' style wallpaper into file '~/.wallpaper'
-		`basename $0` -u                         Set wallpaper to the current style, and refresh the pywal theme
+		`basename $0` -u                         Updates the wallpaper using the current style
 		`basename $0` -p -s sahara               Set 'beach' style wallpaper, and refresh the pywal theme
 		`basename $0` -p -b colorz -s sahara     " with 'colorz' backend
 		`basename $0` -p -b colorz -s sahara -a    " with automatic light/dark mode

--- a/dwall.sh
+++ b/dwall.sh
@@ -122,6 +122,7 @@ set_cinnamon() {
 ## Set wallpaper in GNOME
 set_gnome() {
 	gsettings set org.gnome.desktop.background picture-uri "file://$1"
+	gsettings set org.gnome.desktop.background picture-uri-dark "file://$1"
 	gsettings set org.gnome.desktop.screensaver picture-uri "file://$1"
 }
 


### PR DESCRIPTION
Let me start by saying this is my first contribution ever. So I apologize if I should have this in another way, it's also the first time I write bash scripts.

That said, the `get_style_from_cache` reads the cache file with the path of the current wallpaper and extracts from that the style in use.

I could have made another file that keeps track of the style, and that's probably a better option.

Included in the pr is also a dirty fix for gnome users who use dark theme and by extension the dark wallpaper